### PR TITLE
Fixed error when compiling on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ${OBJ}: config.h
 
 ${BIN}: ${OBJ}
 	@echo "${LD} $^ -o $@ ${LDFLAGS}"
-	@${LD} -o $@ ${LDFLAGS} ${OBJ}
+	@${LD} -o $@ ${OBJ} ${LDFLAGS}
 
 install: ${BIN}
 	mkdir -p ${DESTDIR}${PREFIX}/bin


### PR DESCRIPTION
I fixed the error that occurs when compiling on Ubuntu It's safe to merge [I even have witnesses](http://askubuntu.com/questions/644779/cant-install-swm-on-ubuntu-15-04/)